### PR TITLE
IAM Roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ dist/
 
 # nosetest --with-coverage dumps these in CWD
 .coverage
+cover
 
 Vagrantfile
 

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,10 @@ lint:
 	flake8 stacker_blueprints
 
 test:
-	python setup.py test
+	python setup.py nosetests \
+		--with-coverage \
+		--cover-html \
+		--cover-package=stacker_blueprints \
+		--cover-erase \
+		--cover-branches \
+		--cover-inclusive

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,14 @@ install_requires = [
 ]
 
 tests_require = [
-    "nose",
+    "coverage>=4.5.1",
     "mock~=2.0.0",
     "stacker>=1.1.1",
 ]
 
+setup_requires=[
+    'nose>=1.0',
+]
 
 def read(filename):
     full_path = os.path.join(src_dir, filename)
@@ -34,6 +37,7 @@ if __name__ == "__main__":
         description="Default blueprints for stacker",
         long_description=read("README.rst"),
         packages=find_packages(),
+        setup_requires=setup_requires,
         install_requires=install_requires,
         tests_require=tests_require,
         test_suite="nose.collector",

--- a/tests/fixtures/blueprints/ecs__simple_fargate_service.json
+++ b/tests/fixtures/blueprints/ecs__simple_fargate_service.json
@@ -75,7 +75,7 @@
                                 "Value": "sql://fake_db/fake_db"
                             }
                         ], 
-                        "Essential": "true", 
+                        "Essential": true, 
                         "Image": "fake_repo/image:12345", 
                         "LogConfiguration": {
                             "Ref": "AWS::NoValue"

--- a/tests/fixtures/blueprints/test_iam_ec2_role.json
+++ b/tests/fixtures/blueprints/test_iam_ec2_role.json
@@ -1,0 +1,79 @@
+{
+    "Outputs": {
+        "PolicyName": {
+            "Value": {
+                "Ref": "Policy"
+            }
+        }, 
+        "ec2roleRoleArn": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "ec2role", 
+                    "Arn"
+                ]
+            }
+        }, 
+        "ec2roleRoleName": {
+            "Value": {
+                "Ref": "ec2role"
+            }
+        }
+    }, 
+    "Resources": {
+        "Policy": {
+            "Properties": {
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "logs:CreateLogGroup", 
+                                "logs:CreateLogStream", 
+                                "logs:PutLogEvents"
+                            ], 
+                            "Effect": "Allow", 
+                            "Resource": "arn:aws:logs:*:*:*"
+                        }, 
+                        {
+                            "Action": [
+                                "ecr:GetAuthorizationToken"
+                            ], 
+                            "Effect": "Allow", 
+                            "Resource": [
+                                "*"
+                            ]
+                        }
+                    ]
+                }, 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}-policy"
+                }, 
+                "Roles": [
+                    {
+                        "Ref": "ec2role"
+                    }
+                ]
+            }, 
+            "Type": "AWS::IAM::Policy"
+        }, 
+        "ec2role": {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ], 
+                            "Effect": "Allow", 
+                            "Principal": {
+                                "Service": [
+                                    "ec2.amazonaws.com"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }, 
+            "Type": "AWS::IAM::Role"
+        }
+    }
+}

--- a/tests/fixtures/blueprints/test_iam_role_instance_profile.json
+++ b/tests/fixtures/blueprints/test_iam_role_instance_profile.json
@@ -1,0 +1,100 @@
+{
+    "Outputs": {
+        "InstanceProfileArn": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "ec2roleInstanceProfile", 
+                    "Arn"
+                ]
+            }
+        }, 
+        "PolicyName": {
+            "Value": {
+                "Ref": "Policy"
+            }
+        }, 
+        "ec2roleRoleArn": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "ec2role", 
+                    "Arn"
+                ]
+            }
+        }, 
+        "ec2roleRoleName": {
+            "Value": {
+                "Ref": "ec2role"
+            }
+        }
+    }, 
+    "Resources": {
+        "Policy": {
+            "Properties": {
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "logs:CreateLogGroup", 
+                                "logs:CreateLogStream", 
+                                "logs:PutLogEvents"
+                            ], 
+                            "Effect": "Allow", 
+                            "Resource": "arn:aws:logs:*:*:*"
+                        }, 
+                        {
+                            "Action": [
+                                "ecr:GetAuthorizationToken"
+                            ], 
+                            "Effect": "Allow", 
+                            "Resource": [
+                                "*"
+                            ]
+                        }
+                    ]
+                }, 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}-policy"
+                }, 
+                "Roles": [
+                    {
+                        "Ref": "ec2role"
+                    }
+                ]
+            }, 
+            "Type": "AWS::IAM::Policy"
+        }, 
+        "ec2role": {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ], 
+                            "Effect": "Allow", 
+                            "Principal": {
+                                "Service": [
+                                    "ec2.amazonaws.com"
+                                ]
+                            }
+                        }
+                    ]
+                }, 
+                "ManagedPolicyArns": [
+                    "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
+                ]
+            }, 
+            "Type": "AWS::IAM::Role"
+        }, 
+        "ec2roleInstanceProfile": {
+            "Properties": {
+                "Roles": [
+                    {
+                        "Ref": "ec2role"
+                    }
+                ]
+            }, 
+            "Type": "AWS::IAM::InstanceProfile"
+        }
+    }
+}

--- a/tests/fixtures/blueprints/test_iam_roles.json
+++ b/tests/fixtures/blueprints/test_iam_roles.json
@@ -1,0 +1,115 @@
+{
+    "Outputs": {
+        "PolicyName": {
+            "Value": {
+                "Ref": "Policy"
+            }
+        }, 
+        "ec2roleRoleArn": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "ec2role", 
+                    "Arn"
+                ]
+            }
+        }, 
+        "ec2roleRoleName": {
+            "Value": {
+                "Ref": "ec2role"
+            }
+        }, 
+        "lambdaroleRoleArn": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "lambdarole", 
+                    "Arn"
+                ]
+            }
+        }, 
+        "lambdaroleRoleName": {
+            "Value": {
+                "Ref": "lambdarole"
+            }
+        }
+    }, 
+    "Resources": {
+        "Policy": {
+            "Properties": {
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "logs:CreateLogGroup", 
+                                "logs:CreateLogStream", 
+                                "logs:PutLogEvents"
+                            ], 
+                            "Effect": "Allow", 
+                            "Resource": "arn:aws:logs:*:*:*"
+                        }, 
+                        {
+                            "Action": [
+                                "ecr:GetAuthorizationToken"
+                            ], 
+                            "Effect": "Allow", 
+                            "Resource": [
+                                "*"
+                            ]
+                        }
+                    ]
+                }, 
+                "PolicyName": {
+                    "Fn::Sub": "${AWS::StackName}-policy"
+                }, 
+                "Roles": [
+                    {
+                        "Ref": "ec2role"
+                    }, 
+                    {
+                        "Ref": "lambdarole"
+                    }
+                ]
+            }, 
+            "Type": "AWS::IAM::Policy"
+        }, 
+        "ec2role": {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ], 
+                            "Effect": "Allow", 
+                            "Principal": {
+                                "Service": [
+                                    "ec2.amazonaws.com"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }, 
+            "Type": "AWS::IAM::Role"
+        }, 
+        "lambdarole": {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ], 
+                            "Effect": "Allow", 
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }, 
+            "Type": "AWS::IAM::Role"
+        }
+    }
+}

--- a/tests/test_iam_roles.py
+++ b/tests/test_iam_roles.py
@@ -1,0 +1,109 @@
+from awacs.aws import Allow, Statement
+from awacs import ecr, logs
+
+from stacker.blueprints.testutil import BlueprintTestCase
+from stacker.context import Context
+from stacker.variables import Variable
+
+from stacker_blueprints import iam_roles
+
+
+class TestIamRolesCommon(BlueprintTestCase):
+
+    def setUp(self):
+        self.common_variables = {}
+        self.ctx = Context({
+            'namespace': 'test',
+            'environment': 'test',
+        })
+
+    def generate_variables(self, variable_dict=None):
+        return [Variable(k, v) for k, v in self.common_variables.items()]
+
+    def create_blueprint(self, name):
+        class TestRole(iam_roles.Roles):
+            def generate_policy_statements(self):
+                return [
+                    Statement(
+                        Effect=Allow,
+                        Resource=logs.ARN('*', '*', '*'),
+                        Action=[
+                            logs.CreateLogGroup,
+                            logs.CreateLogStream,
+                            logs.PutLogEvents
+                        ]
+                    ),
+                    Statement(
+                        Effect=Allow,
+                        Resource=['*'],
+                        Action=[ecr.GetAuthorizationToken, ]
+                    )
+                ]
+
+        return TestRole(name, self.ctx)
+
+
+class TestIamRolesBlueprint(TestIamRolesCommon):
+
+    def setUp(self):
+        self.common_variables = {}
+        self.ctx = Context({
+            'namespace': 'test',
+            'environment': 'test',
+        })
+
+    def generate_variables(self, variable_dict=None):
+        return [Variable(k, v) for k, v in self.common_variables.items()]
+
+    def create_blueprint(self, name):
+        class TestRole(iam_roles.Roles):
+            def generate_policy_statements(self):
+                return [
+                    Statement(
+                        Effect=Allow,
+                        Resource=logs.ARN('*', '*', '*'),
+                        Action=[
+                            logs.CreateLogGroup,
+                            logs.CreateLogStream,
+                            logs.PutLogEvents
+                        ]
+                    ),
+                    Statement(
+                        Effect=Allow,
+                        Resource=['*'],
+                        Action=[ecr.GetAuthorizationToken, ]
+                    )
+                ]
+
+        return TestRole(name, self.ctx)
+
+    def test_roles(self):
+        self.common_variables = {
+            'Ec2Roles': [
+                'ec2role'
+            ],
+            'LambdaRoles': [
+                'lambdarole'
+            ],
+        }
+        blueprint = self.create_blueprint('test_iam_roles')
+        blueprint.resolve_variables(self.generate_variables())
+        blueprint.create_template()
+        self.assertRenderedBlueprint(blueprint)
+
+
+class TestIamEc2RoleBlueprint(TestIamRolesCommon):
+
+    def test_role(self):
+        self.common_variables = {
+            'AttachedPolicies': [
+                'arn:aws:iam::aws:policy/CloudWatchLogsFullAccess'
+            ],
+            'InstanceProfile': True,
+            'Name': 'myRole',
+            'Path': '/',
+        }
+        blueprint = self.create_blueprint('test_iam_ec2_role')
+        blueprint.resolve_variables(self.generate_variables())
+        blueprint.create_template()
+        self.assertRenderedBlueprint(blueprint)


### PR DESCRIPTION
- Dropped name argument from create_policy. Is was being called by create_template without any arguments.                                                                                                                                                                                                                                     
- Check at least one Ec2Role or LambdaRole is defined.                                                                                                                                                                                                                      
- Added support for new variable AttachedPolicies. If defined its values are passed to ManagedPolicyArns in the IAM Role create.
- Added new variable InstanceProfile. If true the role will be created as an instance profile.
- Added new variable Path. If defined the Path will be set on the Role and the InstanceProfile.
- Coverage support. Run coverage with tests                                                                                                                                                                                                                                 
- Added tests.