### PR TITLE
Improving python 3 support: changing iteritems to items

### DIFF
--- a/stacker_blueprints/route53.py
+++ b/stacker_blueprints/route53.py
@@ -169,7 +169,7 @@ class DNSRecords(Blueprint):
         """Accept list of record_set_group dicts.
         Return list of record_set_group objects."""
         record_set_groups = []
-        for name, group in record_set_group_dicts.iteritems():
+        for name, group in record_set_group_dicts.items():
             # pop removes the 'Enabled' key and tests if True.
             if group.pop('Enabled', True):
                 record_set_groups.append(

--- a/stacker_blueprints/sns.py
+++ b/stacker_blueprints/sns.py
@@ -53,7 +53,7 @@ def validate_topic(topic):
 
 def validate_topics(topics):
     validated_topics = {}
-    for topic_name, topic_config in topics.iteritems():
+    for topic_name, topic_config in topics.items():
         validated_topics[topic_name] = validate_topic(topic_config)
 
     return validated_topics
@@ -75,7 +75,7 @@ class Topics(Blueprint):
     def create_template(self):
         variables = self.get_variables()
 
-        for topic_name, topic_config in variables["Topics"].iteritems():
+        for topic_name, topic_config in variables["Topics"].items():
             self.create_topic(topic_name, topic_config)
 
     def create_sqs_policy(self, topic_name, topic_arn, topic_subs):


### PR DESCRIPTION
Python 3 dicts don't have `iteritems` available, so I am requesting we use `items` instead to be compatible python3