### PR TITLE
Update EFS blueprint to use TroposphereType as variable type of FileSystem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ src_dir = os.path.dirname(__file__)
 install_requires = [
     "python-dateutil<3.0.0",
     "stacker>=1.7.0",
-    "troposphere>=2.3.2",
+    "troposphere>=2.6.2",
     "awacs>=0.8.2",
 ]
 

--- a/stacker_blueprints/efs.py
+++ b/stacker_blueprints/efs.py
@@ -1,5 +1,5 @@
 from troposphere import ec2, efs
-from troposphere import Join, Output, Ref, GetAtt
+from troposphere import Tags, Join, Output, Ref, GetAtt
 
 from stacker.blueprints.base import Blueprint
 from stacker.blueprints.variables.types import TroposphereType
@@ -203,10 +203,20 @@ class ElasticFileSystem(Blueprint):
         self.create_efs_mount_targets(fs)
 
 
+class _AccessPoint(efs.AccessPoint):
+    """Class to replace Tags property, since original troposphere type does not
+    accept a list of tags
+    """
+    props = efs.AccessPoint.props
+    props.update({
+        'AccessPointTags': ((Tags, list), False)
+    })
+
+
 class AccessPoints(Blueprint):
     VARIABLES = {
         'AccessPoints': {
-            'type': TroposphereType(efs.AccessPoint, many=True),
+            'type': TroposphereType(_AccessPoint, many=True),
             'description': 'A dictionary of the AccessPoints to create. The '
                            'key being the CFN logical resource name, the '
                            'value being a dictionary of attributes for '

--- a/stacker_blueprints/efs.py
+++ b/stacker_blueprints/efs.py
@@ -139,7 +139,7 @@ class ElasticFileSystem(Blueprint):
         v = self.get_variables()
 
         created_groups = []
-        for sg in v['SecurityGroups']:
+        for sg in v['SecurityGroups'] or {}:
             sg.VpcId = v['VpcId']
             sg.Tags = merge_tags(v['Tags'], getattr(sg, 'Tags', {}))
 

--- a/stacker_blueprints/efs.py
+++ b/stacker_blueprints/efs.py
@@ -1,5 +1,5 @@
 from troposphere import ec2, efs
-from troposphere import Join, Output, Ref
+from troposphere import Join, Output, Ref, GetAtt
 
 from stacker.blueprints.base import Blueprint
 from stacker.blueprints.variables.types import TroposphereType
@@ -201,3 +201,39 @@ class ElasticFileSystem(Blueprint):
     def create_template(self):
         fs = self.create_efs_filesystem()
         self.create_efs_mount_targets(fs)
+
+
+class AccessPoints(Blueprint):
+    VARIABLES = {
+        'AccessPoints': {
+            'type': TroposphereType(efs.AccessPoint, many=True),
+            'description': 'A dictionary of the AccessPoints to create. The '
+                           'key being the CFN logical resource name, the '
+                           'value being a dictionary of attributes for '
+                           'the troposphere efs.FileSystem type.',
+        },
+        'Tags': {
+            'type': dict,
+            'description': 'Tags to associate with the created resources',
+            'default': {}
+        }
+    }
+
+    def create_template(self):
+        t = self.template
+        v = self.get_variables()
+
+        access_points = v.get('AccessPoints')
+        tags = v.get('Tags')
+
+        for ap in access_points:
+            # This is a major hack to inject extra tags in resources
+            ap.AccessPointTags = merge_tags(tags, getattr(ap, 'Tags', {}))
+            ap_name = ap.name
+            ap = t.add_resource(ap)
+            t.add_output(Output(
+                '{}Id'.format(ap_name),
+                Value=GetAtt(ap, 'AccessPointId')))
+            t.add_output(Output(
+                '{}Arn'.format(ap_name),
+                Value=GetAtt(ap, 'Arn')))

--- a/stacker_blueprints/msk.py
+++ b/stacker_blueprints/msk.py
@@ -31,4 +31,4 @@ class Cluster(Blueprint):
         clusters = v.get('Clusters')
         for cluster in clusters:
             t.add_resource(cluster)
-            t.add_output(Output(cluster.title, Value=Ref(cluster)))
+            t.add_output(Output(cluster.title + 'Arn', Value=Ref(cluster)))

--- a/stacker_blueprints/msk.py
+++ b/stacker_blueprints/msk.py
@@ -1,0 +1,34 @@
+from stacker.blueprints.base import Blueprint
+from stacker.blueprints.variables.types import TroposphereType
+from troposphere import Output, Ref, Tags
+from troposphere import msk
+
+
+class _Cluster(msk.Cluster):
+    """Class to replace Tags property, since original troposphere type does not
+    accept a list of tags
+    """
+    props = msk.Cluster.props
+    props.update({
+        'Tags': ((Tags, list), False)
+    })
+
+
+class Cluster(Blueprint):
+    VARIABLES = {
+        'Clusters': {
+            'type': TroposphereType(_Cluster, many=True),
+            'description': 'A dictinary where key is the resource name and '
+                           'the value is a MSK cluster as defined by '
+                           'Cloudformation'
+        }
+    }
+
+    def create_template(self):
+        v = self.get_variables()
+        t = self.template
+
+        clusters = v.get('Clusters')
+        for cluster in clusters:
+            t.add_resource(cluster)
+            t.add_output(Output(cluster.title, Value=Ref(cluster)))

--- a/stacker_blueprints/msk.py
+++ b/stacker_blueprints/msk.py
@@ -10,7 +10,7 @@ class _Cluster(msk.Cluster):
     """
     props = msk.Cluster.props
     props.update({
-        'Tags': ((Tags, list), False)
+        'Tags': ((Tags, dict), False)
     })
 
 

--- a/tests/fixtures/blueprints/access_points.json
+++ b/tests/fixtures/blueprints/access_points.json
@@ -1,0 +1,41 @@
+{
+    "Outputs": {
+        "FirstAccessPointArn": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "FirstAccessPoint",
+                    "Arn"
+                ]
+            }
+        },
+        "FirstAccessPointId": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "FirstAccessPoint",
+                    "AccessPointId"
+                ]
+            }
+        }
+    },
+    "Resources": {
+        "FirstAccessPoint": {
+            "Properties": {
+                "AccessPointTags": [],
+                "FileSystemId": "fs-11111111",
+                "PosixUser": {
+                    "Gid": "1000",
+                    "Uid": "1000"
+                },
+                "RootDirectory": {
+                    "CreationInfo": {
+                        "OwnerGid": "1000",
+                        "OwnerUid": "1000",
+                        "Permissions": "755"
+                    },
+                    "Path": "/data/"
+                }
+            },
+            "Type": "AWS::EFS::AccessPoint"
+        }
+    }
+}

--- a/tests/fixtures/blueprints/efs.json
+++ b/tests/fixtures/blueprints/efs.json
@@ -1,0 +1,139 @@
+{
+    "Outputs": {
+        "EfsFileSystemId": {
+            "Value": {
+                "Ref": "EfsFileSystem"
+            }
+        }, 
+        "EfsMountTargetIds": {
+            "Value": {
+                "Fn::Join": [
+                    ",", 
+                    [
+                        {
+                            "Ref": "EfsMountTarget1"
+                        }, 
+                        {
+                            "Ref": "EfsMountTarget2"
+                        }
+                    ]
+                ]
+            }
+        }, 
+        "EfsNewSecurityGroupIds": {
+            "Value": {
+                "Fn::Join": [
+                    ",", 
+                    [
+                        {
+                            "Ref": "EfsSg1"
+                        }, 
+                        {
+                            "Ref": "EfsSg2"
+                        }
+                    ]
+                ]
+            }
+        }
+    }, 
+    "Resources": {
+        "EfsFileSystem": {
+            "Properties": {
+                "FileSystemTags": [
+                    {
+                        "Key": "Hello", 
+                        "Value": "World"
+                    }
+                ], 
+                "PerformanceMode": "generalPurpose"
+            }, 
+            "Type": "AWS::EFS::FileSystem"
+        }, 
+        "EfsMountTarget1": {
+            "Properties": {
+                "FileSystemId": {
+                    "Ref": "EfsFileSystem"
+                }, 
+                "IpAddress": "172.16.1.10", 
+                "SecurityGroups": [
+                    {
+                        "Ref": "EfsSg1"
+                    }, 
+                    {
+                        "Ref": "EfsSg2"
+                    }, 
+                    "sg-22222222", 
+                    "sg-33333333"
+                ], 
+                "SubnetId": "subnet-11111111"
+            }, 
+            "Type": "AWS::EFS::MountTarget"
+        }, 
+        "EfsMountTarget2": {
+            "Properties": {
+                "FileSystemId": {
+                    "Ref": "EfsFileSystem"
+                }, 
+                "IpAddress": "172.16.2.10", 
+                "SecurityGroups": [
+                    {
+                        "Ref": "EfsSg1"
+                    }, 
+                    {
+                        "Ref": "EfsSg2"
+                    }, 
+                    "sg-22222222", 
+                    "sg-33333333"
+                ], 
+                "SubnetId": "subnet-22222222"
+            }, 
+            "Type": "AWS::EFS::MountTarget"
+        }, 
+        "EfsSg1": {
+            "Properties": {
+                "GroupDescription": "EFS SG 1", 
+                "SecurityGroupIngress": [
+                    {
+                        "CidrIp": "172.16.0.0/12", 
+                        "FromPort": 2049, 
+                        "IpProtocol": "tcp", 
+                        "ToPort": 2049
+                    }
+                ], 
+                "Tags": [
+                    {
+                        "Key": "Foo", 
+                        "Value": "Bar"
+                    }, 
+                    {
+                        "Key": "Hello", 
+                        "Value": "World"
+                    }
+                ], 
+                "VpcId": "vpc-11111111"
+            }, 
+            "Type": "AWS::EC2::SecurityGroup"
+        }, 
+        "EfsSg2": {
+            "Properties": {
+                "GroupDescription": "EFS SG 2", 
+                "SecurityGroupIngress": [
+                    {
+                        "FromPort": 2049, 
+                        "IpProtocol": "tcp", 
+                        "SourceSecurityGroupId": "sg-11111111", 
+                        "ToPort": 2049
+                    }
+                ], 
+                "Tags": [
+                    {
+                        "Key": "Hello", 
+                        "Value": "World"
+                    }
+                ], 
+                "VpcId": "vpc-11111111"
+            }, 
+            "Type": "AWS::EC2::SecurityGroup"
+        }
+    }
+}

--- a/tests/fixtures/blueprints/efs_access_points.json
+++ b/tests/fixtures/blueprints/efs_access_points.json
@@ -32,7 +32,7 @@
                         "OwnerUid": "1000",
                         "Permissions": "755"
                     },
-                    "Path": "/data/"
+                    "Path": "/data"
                 }
             },
             "Type": "AWS::EFS::AccessPoint"

--- a/tests/fixtures/blueprints/efs_with_subnets.json
+++ b/tests/fixtures/blueprints/efs_with_subnets.json
@@ -4,30 +4,30 @@
             "Value": {
                 "Ref": "EfsFileSystem"
             }
-        }, 
+        },
         "EfsMountTargetIds": {
             "Value": {
                 "Fn::Join": [
-                    ",", 
+                    ",",
                     [
                         {
                             "Ref": "EfsMountTarget1"
-                        }, 
+                        },
                         {
                             "Ref": "EfsMountTarget2"
                         }
                     ]
                 ]
             }
-        }, 
+        },
         "EfsNewSecurityGroupIds": {
             "Value": {
                 "Fn::Join": [
-                    ",", 
+                    ",",
                     [
                         {
                             "Ref": "EfsSg1"
-                        }, 
+                        },
                         {
                             "Ref": "EfsSg2"
                         }
@@ -35,104 +35,104 @@
                 ]
             }
         }
-    }, 
+    },
     "Resources": {
         "EfsFileSystem": {
             "Properties": {
                 "FileSystemTags": [
                     {
-                        "Key": "Hello", 
+                        "Key": "Hello",
                         "Value": "World"
                     }
-                ], 
+                ],
                 "PerformanceMode": "generalPurpose"
-            }, 
+            },
             "Type": "AWS::EFS::FileSystem"
-        }, 
+        },
         "EfsMountTarget1": {
             "Properties": {
                 "FileSystemId": {
                     "Ref": "EfsFileSystem"
-                }, 
-                "IpAddress": "172.16.1.10", 
+                },
+                "IpAddress": "172.16.1.10",
                 "SecurityGroups": [
                     {
                         "Ref": "EfsSg1"
-                    }, 
+                    },
                     {
                         "Ref": "EfsSg2"
-                    }, 
-                    "sg-22222222", 
+                    },
+                    "sg-22222222",
                     "sg-33333333"
-                ], 
+                ],
                 "SubnetId": "subnet-11111111"
-            }, 
+            },
             "Type": "AWS::EFS::MountTarget"
-        }, 
+        },
         "EfsMountTarget2": {
             "Properties": {
                 "FileSystemId": {
                     "Ref": "EfsFileSystem"
-                }, 
-                "IpAddress": "172.16.2.10", 
+                },
+                "IpAddress": "172.16.2.10",
                 "SecurityGroups": [
                     {
                         "Ref": "EfsSg1"
-                    }, 
+                    },
                     {
                         "Ref": "EfsSg2"
-                    }, 
-                    "sg-22222222", 
+                    },
+                    "sg-22222222",
                     "sg-33333333"
-                ], 
+                ],
                 "SubnetId": "subnet-22222222"
-            }, 
+            },
             "Type": "AWS::EFS::MountTarget"
-        }, 
+        },
         "EfsSg1": {
             "Properties": {
-                "GroupDescription": "EFS SG 1", 
+                "GroupDescription": "EFS SG 1",
                 "SecurityGroupIngress": [
                     {
-                        "CidrIp": "172.16.0.0/12", 
-                        "FromPort": 2049, 
-                        "IpProtocol": "tcp", 
+                        "CidrIp": "172.16.0.0/12",
+                        "FromPort": 2049,
+                        "IpProtocol": "tcp",
                         "ToPort": 2049
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Key": "Foo", 
+                        "Key": "Foo",
                         "Value": "Bar"
-                    }, 
+                    },
                     {
-                        "Key": "Hello", 
+                        "Key": "Hello",
                         "Value": "World"
                     }
-                ], 
+                ],
                 "VpcId": "vpc-11111111"
-            }, 
+            },
             "Type": "AWS::EC2::SecurityGroup"
-        }, 
+        },
         "EfsSg2": {
             "Properties": {
-                "GroupDescription": "EFS SG 2", 
+                "GroupDescription": "EFS SG 2",
                 "SecurityGroupIngress": [
                     {
-                        "FromPort": 2049, 
-                        "IpProtocol": "tcp", 
-                        "SourceSecurityGroupId": "sg-11111111", 
+                        "FromPort": 2049,
+                        "IpProtocol": "tcp",
+                        "SourceSecurityGroupId": "sg-11111111",
                         "ToPort": 2049
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Key": "Hello", 
+                        "Key": "Hello",
                         "Value": "World"
                     }
-                ], 
+                ],
                 "VpcId": "vpc-11111111"
-            }, 
+            },
             "Type": "AWS::EC2::SecurityGroup"
         }
     }

--- a/tests/fixtures/blueprints/efs_with_subnets_str.json
+++ b/tests/fixtures/blueprints/efs_with_subnets_str.json
@@ -1,0 +1,139 @@
+{
+    "Outputs": {
+        "EfsFileSystemId": {
+            "Value": {
+                "Ref": "EfsFileSystem"
+            }
+        },
+        "EfsMountTargetIds": {
+            "Value": {
+                "Fn::Join": [
+                    ",",
+                    [
+                        {
+                            "Ref": "EfsMountTarget1"
+                        },
+                        {
+                            "Ref": "EfsMountTarget2"
+                        }
+                    ]
+                ]
+            }
+        },
+        "EfsNewSecurityGroupIds": {
+            "Value": {
+                "Fn::Join": [
+                    ",",
+                    [
+                        {
+                            "Ref": "EfsSg1"
+                        },
+                        {
+                            "Ref": "EfsSg2"
+                        }
+                    ]
+                ]
+            }
+        }
+    },
+    "Resources": {
+        "EfsFileSystem": {
+            "Properties": {
+                "FileSystemTags": [
+                    {
+                        "Key": "Hello",
+                        "Value": "World"
+                    }
+                ],
+                "PerformanceMode": "generalPurpose"
+            },
+            "Type": "AWS::EFS::FileSystem"
+        },
+        "EfsMountTarget1": {
+            "Properties": {
+                "FileSystemId": {
+                    "Ref": "EfsFileSystem"
+                },
+                "IpAddress": "172.16.1.10",
+                "SecurityGroups": [
+                    {
+                        "Ref": "EfsSg1"
+                    },
+                    {
+                        "Ref": "EfsSg2"
+                    },
+                    "sg-22222222",
+                    "sg-33333333"
+                ],
+                "SubnetId": "subnet-33333333"
+            },
+            "Type": "AWS::EFS::MountTarget"
+        },
+        "EfsMountTarget2": {
+            "Properties": {
+                "FileSystemId": {
+                    "Ref": "EfsFileSystem"
+                },
+                "IpAddress": "172.16.2.10",
+                "SecurityGroups": [
+                    {
+                        "Ref": "EfsSg1"
+                    },
+                    {
+                        "Ref": "EfsSg2"
+                    },
+                    "sg-22222222",
+                    "sg-33333333"
+                ],
+                "SubnetId": "subnet-44444444"
+            },
+            "Type": "AWS::EFS::MountTarget"
+        },
+        "EfsSg1": {
+            "Properties": {
+                "GroupDescription": "EFS SG 1",
+                "SecurityGroupIngress": [
+                    {
+                        "CidrIp": "172.16.0.0/12",
+                        "FromPort": 2049,
+                        "IpProtocol": "tcp",
+                        "ToPort": 2049
+                    }
+                ],
+                "Tags": [
+                    {
+                        "Key": "Foo",
+                        "Value": "Bar"
+                    },
+                    {
+                        "Key": "Hello",
+                        "Value": "World"
+                    }
+                ],
+                "VpcId": "vpc-11111111"
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "EfsSg2": {
+            "Properties": {
+                "GroupDescription": "EFS SG 2",
+                "SecurityGroupIngress": [
+                    {
+                        "FromPort": 2049,
+                        "IpProtocol": "tcp",
+                        "SourceSecurityGroupId": "sg-11111111",
+                        "ToPort": 2049
+                    }
+                ],
+                "Tags": [
+                    {
+                        "Key": "Hello",
+                        "Value": "World"
+                    }
+                ],
+                "VpcId": "vpc-11111111"
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        }
+    }
+}

--- a/tests/fixtures/blueprints/msk_cluster_all_required_opts.json
+++ b/tests/fixtures/blueprints/msk_cluster_all_required_opts.json
@@ -1,0 +1,81 @@
+{
+    "Outputs": {
+        "ClusterWithAllProperties": {
+            "Value": {
+                "Ref": "ClusterWithAllProperties"
+            }
+        }
+    },
+    "Resources": {
+        "ClusterWithAllProperties": {
+            "Properties": {
+                "BrokerNodeGroupInfo": {
+                    "BrokerAZDistribution": "DEFAULT",
+                    "ClientSubnets": [
+                        "subnet-abc09876",
+                        "subnet-def54321",
+                        "subnet-cdb5678"
+                    ],
+                    "InstanceType": "kafka.m5.large",
+                    "SecurityGroups": [
+                        "sg-abcdef0123456789a"
+                    ],
+                    "StorageInfo": {
+                        "EBSStorageInfo": {
+                            "VolumeSize": 100
+                        }
+                    }
+                },
+                "ClientAuthentication": {
+                    "Tls": {
+                        "CertificateAuthorityArnList": [
+                            "ReplaceWithCAArn"
+                        ]
+                    }
+                },
+                "ClusterName": "ClusterWithAllProperties",
+                "ConfigurationInfo": {
+                    "Arn": "arn:aws:kafka:us-east-1:000000000011:configuration/ConfigName/abcdef0-1234-5678-9abc-0123456789ab-2",
+                    "Revision": 1
+                },
+                "EncryptionInfo": {
+                    "EncryptionAtRest": {
+                        "DataVolumeKMSKeyId": "ReplaceWithKmsKeyArn"
+                    },
+                    "EncryptionInTransit": {
+                        "ClientBroker": "TLS",
+                        "InCluster": "true"
+                    }
+                },
+                "EnhancedMonitoring": "PER_BROKER",
+                "KafkaVersion": "2.2.1",
+                "NumberOfBrokerNodes": 3,
+                "OpenMonitoring": {
+                    "Prometheus": {
+                        "JmxExporter": {
+                            "EnabledInBroker": "true"
+                        },
+                        "NodeExporter": {
+                            "EnabledInBroker": "true"
+                        }
+                    }
+                },
+                "Tags": [
+                    {
+                        "Key": "MyKey1",
+                        "Value": "myValue1"
+                    },
+                    {
+                        "Key": "MyKey2",
+                        "Value": "myValue2"
+                    },
+                    {
+                        "Key": "MyKey3",
+                        "Value": "myValue3"
+                    }
+                ]
+            },
+            "Type": "AWS::MSK::Cluster"
+        }
+    }
+}

--- a/tests/fixtures/blueprints/msk_cluster_all_required_opts.json
+++ b/tests/fixtures/blueprints/msk_cluster_all_required_opts.json
@@ -60,20 +60,11 @@
                         }
                     }
                 },
-                "Tags": [
-                    {
-                        "Key": "MyKey1",
-                        "Value": "myValue1"
-                    },
-                    {
-                        "Key": "MyKey2",
-                        "Value": "myValue2"
-                    },
-                    {
-                        "Key": "MyKey3",
-                        "Value": "myValue3"
-                    }
-                ]
+                "Tags": {
+                    "MyKey1": "myValue1",
+                    "MyKey2": "myValue2",
+                    "MyKey3": "myValue3"
+                }
             },
             "Type": "AWS::MSK::Cluster"
         }

--- a/tests/fixtures/blueprints/msk_cluster_all_required_opts.json
+++ b/tests/fixtures/blueprints/msk_cluster_all_required_opts.json
@@ -1,6 +1,6 @@
 {
     "Outputs": {
-        "ClusterWithAllProperties": {
+        "ClusterWithAllPropertiesArn": {
             "Value": {
                 "Ref": "ClusterWithAllProperties"
             }

--- a/tests/fixtures/blueprints/msk_cluster_base.json
+++ b/tests/fixtures/blueprints/msk_cluster_base.json
@@ -1,6 +1,6 @@
 {
     "Outputs": {
-        "testCluster": {
+        "testClusterArn": {
             "Value": {
                 "Ref": "testCluster"
             }

--- a/tests/fixtures/blueprints/msk_cluster_base.json
+++ b/tests/fixtures/blueprints/msk_cluster_base.json
@@ -1,0 +1,61 @@
+{
+    "Outputs": {
+        "testCluster": {
+            "Value": {
+                "Ref": "testCluster"
+            }
+        }
+    }, 
+    "Resources": {
+        "testCluster": {
+            "Properties": {
+                "BrokerNodeGroupInfo": {
+                    "BrokerAZDistribution": "DEFAULT", 
+                    "ClientSubnets": [
+                        "subnet-abc09876", 
+                        "subnet-def54321", 
+                        "subnet-cdb5678"
+                    ], 
+                    "InstanceType": "kafka.m5.xlarge", 
+                    "SecurityGroups": [
+                        "sg-abcdef0123456789a"
+                    ], 
+                    "StorageInfo": {
+                        "EBSStorageInfo": {
+                            "VolumeSize": 800
+                        }
+                    }
+                }, 
+                "ClusterName": "test-kafka", 
+                "ConfigurationInfo": {
+                    "Arn": "arn:aws:kafka:us-east-1:000000000011:configuration/ConfigName/abcdef0-1234-5678-9abc-0123456789ab-2", 
+                    "Revision": 1
+                }, 
+                "EncryptionInfo": {
+                    "EncryptionInTransit": {
+                        "ClientBroker": "TLS_PLAINTEXT", 
+                        "InCluster": "false"
+                    }
+                }, 
+                "EnhancedMonitoring": "PER_TOPIC_PER_BROKER", 
+                "KafkaVersion": "1.1.1", 
+                "NumberOfBrokerNodes": 3, 
+                "Tags": [
+                    {
+                        "Key": "MyKey1", 
+                        "Value": "myValue1"
+                    }, 
+                    {
+                        "Key": "MyKey2", 
+                        "Value": "myValue2"
+                    }, 
+                    {
+                        "Key": "MyKey3", 
+                        "Value": "myValue3"
+                    }
+                ]
+            }, 
+            "Type": "AWS::MSK::Cluster"
+        }
+    }
+}

--- a/tests/fixtures/blueprints/msk_cluster_base.json
+++ b/tests/fixtures/blueprints/msk_cluster_base.json
@@ -5,56 +5,47 @@
                 "Ref": "testCluster"
             }
         }
-    }, 
+    },
     "Resources": {
         "testCluster": {
             "Properties": {
                 "BrokerNodeGroupInfo": {
-                    "BrokerAZDistribution": "DEFAULT", 
+                    "BrokerAZDistribution": "DEFAULT",
                     "ClientSubnets": [
-                        "subnet-abc09876", 
-                        "subnet-def54321", 
+                        "subnet-abc09876",
+                        "subnet-def54321",
                         "subnet-cdb5678"
-                    ], 
-                    "InstanceType": "kafka.m5.xlarge", 
+                    ],
+                    "InstanceType": "kafka.m5.xlarge",
                     "SecurityGroups": [
                         "sg-abcdef0123456789a"
-                    ], 
+                    ],
                     "StorageInfo": {
                         "EBSStorageInfo": {
                             "VolumeSize": 800
                         }
                     }
-                }, 
-                "ClusterName": "test-kafka", 
+                },
+                "ClusterName": "test-kafka",
                 "ConfigurationInfo": {
-                    "Arn": "arn:aws:kafka:us-east-1:000000000011:configuration/ConfigName/abcdef0-1234-5678-9abc-0123456789ab-2", 
+                    "Arn": "arn:aws:kafka:us-east-1:000000000011:configuration/ConfigName/abcdef0-1234-5678-9abc-0123456789ab-2",
                     "Revision": 1
-                }, 
+                },
                 "EncryptionInfo": {
                     "EncryptionInTransit": {
-                        "ClientBroker": "TLS_PLAINTEXT", 
+                        "ClientBroker": "TLS_PLAINTEXT",
                         "InCluster": "false"
                     }
-                }, 
-                "EnhancedMonitoring": "PER_TOPIC_PER_BROKER", 
-                "KafkaVersion": "1.1.1", 
-                "NumberOfBrokerNodes": 3, 
-                "Tags": [
-                    {
-                        "Key": "MyKey1", 
-                        "Value": "myValue1"
-                    }, 
-                    {
-                        "Key": "MyKey2", 
-                        "Value": "myValue2"
-                    }, 
-                    {
-                        "Key": "MyKey3", 
-                        "Value": "myValue3"
-                    }
-                ]
-            }, 
+                },
+                "EnhancedMonitoring": "PER_TOPIC_PER_BROKER",
+                "KafkaVersion": "1.1.1",
+                "NumberOfBrokerNodes": 3,
+                "Tags": {
+                    "MyKey1": "myValue1",
+                    "MyKey2": "myValue2",
+                    "MyKey3": "myValue3"
+                }
+            },
             "Type": "AWS::MSK::Cluster"
         }
     }

--- a/tests/fixtures/blueprints/msk_cluster_with_required_opts.json
+++ b/tests/fixtures/blueprints/msk_cluster_with_required_opts.json
@@ -1,0 +1,27 @@
+{
+    "Outputs": {
+        "ClusterWithRequiredProperties": {
+            "Value": {
+                "Ref": "ClusterWithRequiredProperties"
+            }
+        }
+    }, 
+    "Resources": {
+        "ClusterWithRequiredProperties": {
+            "Properties": {
+                "BrokerNodeGroupInfo": {
+                    "ClientSubnets": [
+                        "subnet-abc09876", 
+                        "subnet-def54321", 
+                        "subnet-cdb5678"
+                    ], 
+                    "InstanceType": "kafka.m5.large"
+                }, 
+                "ClusterName": "ClusterWithRequiredProperties", 
+                "KafkaVersion": "2.2.1", 
+                "NumberOfBrokerNodes": 3
+            }, 
+            "Type": "AWS::MSK::Cluster"
+        }
+    }
+}

--- a/tests/fixtures/blueprints/msk_cluster_with_required_opts.json
+++ b/tests/fixtures/blueprints/msk_cluster_with_required_opts.json
@@ -1,26 +1,26 @@
 {
     "Outputs": {
-        "ClusterWithRequiredProperties": {
+        "ClusterWithRequiredPropertiesArn": {
             "Value": {
                 "Ref": "ClusterWithRequiredProperties"
             }
         }
-    }, 
+    },
     "Resources": {
         "ClusterWithRequiredProperties": {
             "Properties": {
                 "BrokerNodeGroupInfo": {
                     "ClientSubnets": [
-                        "subnet-abc09876", 
-                        "subnet-def54321", 
+                        "subnet-abc09876",
+                        "subnet-def54321",
                         "subnet-cdb5678"
-                    ], 
+                    ],
                     "InstanceType": "kafka.m5.large"
-                }, 
-                "ClusterName": "ClusterWithRequiredProperties", 
-                "KafkaVersion": "2.2.1", 
+                },
+                "ClusterName": "ClusterWithRequiredProperties",
+                "KafkaVersion": "2.2.1",
                 "NumberOfBrokerNodes": 3
-            }, 
+            },
             "Type": "AWS::MSK::Cluster"
         }
     }

--- a/tests/fixtures/blueprints/network_private_with_multiple_routes.json
+++ b/tests/fixtures/blueprints/network_private_with_multiple_routes.json
@@ -1,0 +1,149 @@
+{
+    "Outputs": {
+        "AvailabilityZone": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "AvailabilityZone"
+                ]
+            }
+        },
+        "CidrBlock": {
+            "Value": "10.0.0.0/24"
+        },
+        "DefaultRouteId": {
+            "Value": {
+                "Ref": "DefaultRoute"
+            }
+        },
+        "Ipv6CidrBlocks": {
+            "Value": {
+                "Fn::Join": [
+                    ",",
+                    {
+                        "Fn::GetAtt": [
+                            "Subnet",
+                            "Ipv6CidrBlocks"
+                        ]
+                    }
+                ]
+            }
+        },
+        "NetworkAclAssociationId": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "NetworkAclAssociationId"
+                ]
+            }
+        },
+        "NetworkType": {
+            "Value": "private"
+        },
+        "Route1": {
+            "Value": {
+                "Ref": "Route1"
+            }
+        },
+        "Route2": {
+            "Value": {
+                "Ref": "Route2"
+            }
+        },
+        "RouteTableId": {
+            "Value": {
+                "Ref": "RouteTable"
+            }
+        },
+        "SubnetId": {
+            "Value": {
+                "Ref": "Subnet"
+            }
+        },
+        "SubnetRouteTableAssociationId": {
+            "Value": {
+                "Ref": "SubnetRouteTableAssociation"
+            }
+        },
+        "VpcId": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "VpcId"
+                ]
+            }
+        }
+    },
+    "Resources": {
+        "DefaultRoute": {
+            "Properties": {
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "GatewayId": {
+                    "Ref": "AWS::NoValue"
+                },
+                "NatGatewayId": "nat-abc1234z",
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                }
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "Route1": {
+            "Properties": {
+                "DestinationCidrBlock": "127.127.127.127/32",
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                },
+                "VpcPeeringConnectionId": "pcx-abcde123456789000"
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "Route2": {
+            "Properties": {
+                "DestinationCidrBlock": "127.127.127.128/32",
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                },
+                "VpcPeeringConnectionId": "pcx-abcde123456789001"
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "RouteTable": {
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "NetworkType",
+                        "Value": "private"
+                    }
+                ],
+                "VpcId": "vpcabc1234"
+            },
+            "Type": "AWS::EC2::RouteTable"
+        },
+        "Subnet": {
+            "Properties": {
+                "AvailabilityZone": "us-east-1a",
+                "CidrBlock": "10.0.0.0/24",
+                "Tags": [
+                    {
+                        "Key": "NetworkType",
+                        "Value": "private"
+                    }
+                ],
+                "VpcId": "vpcabc1234"
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "SubnetRouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "Subnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        }
+    }
+}

--- a/tests/fixtures/blueprints/network_private_with_single_route.json
+++ b/tests/fixtures/blueprints/network_private_with_single_route.json
@@ -1,0 +1,134 @@
+{
+    "Outputs": {
+        "AvailabilityZone": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "AvailabilityZone"
+                ]
+            }
+        },
+        "CidrBlock": {
+            "Value": "10.0.0.0/24"
+        },
+        "DefaultRouteId": {
+            "Value": {
+                "Ref": "DefaultRoute"
+            }
+        },
+        "Ipv6CidrBlocks": {
+            "Value": {
+                "Fn::Join": [
+                    ",",
+                    {
+                        "Fn::GetAtt": [
+                            "Subnet",
+                            "Ipv6CidrBlocks"
+                        ]
+                    }
+                ]
+            }
+        },
+        "NetworkAclAssociationId": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "NetworkAclAssociationId"
+                ]
+            }
+        },
+        "NetworkType": {
+            "Value": "private"
+        },
+        "Route1": {
+            "Value": {
+                "Ref": "Route1"
+            }
+        },
+        "RouteTableId": {
+            "Value": {
+                "Ref": "RouteTable"
+            }
+        },
+        "SubnetId": {
+            "Value": {
+                "Ref": "Subnet"
+            }
+        },
+        "SubnetRouteTableAssociationId": {
+            "Value": {
+                "Ref": "SubnetRouteTableAssociation"
+            }
+        },
+        "VpcId": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "VpcId"
+                ]
+            }
+        }
+    },
+    "Resources": {
+        "DefaultRoute": {
+            "Properties": {
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "GatewayId": {
+                    "Ref": "AWS::NoValue"
+                },
+                "NatGatewayId": "nat-abc1234z",
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                }
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "Route1": {
+            "Properties": {
+                "DestinationCidrBlock": "127.127.127.127/32",
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                },
+                "VpcPeeringConnectionId": "pcx-abcde123456789000"
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "RouteTable": {
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "NetworkType",
+                        "Value": "private"
+                    }
+                ],
+                "VpcId": "vpcabc1234"
+            },
+            "Type": "AWS::EC2::RouteTable"
+        },
+        "Subnet": {
+            "Properties": {
+                "AvailabilityZone": "us-east-1a",
+                "CidrBlock": "10.0.0.0/24",
+                "Tags": [
+                    {
+                        "Key": "NetworkType",
+                        "Value": "private"
+                    }
+                ],
+                "VpcId": "vpcabc1234"
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "SubnetRouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "Subnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        }
+    }
+}

--- a/tests/fixtures/blueprints/network_private_without_extra_routes.json
+++ b/tests/fixtures/blueprints/network_private_without_extra_routes.json
@@ -1,0 +1,119 @@
+{
+    "Outputs": {
+        "AvailabilityZone": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "AvailabilityZone"
+                ]
+            }
+        },
+        "CidrBlock": {
+            "Value": "10.0.0.0/24"
+        },
+        "DefaultRouteId": {
+            "Value": {
+                "Ref": "DefaultRoute"
+            }
+        },
+        "Ipv6CidrBlocks": {
+            "Value": {
+                "Fn::Join": [
+                    ",",
+                    {
+                        "Fn::GetAtt": [
+                            "Subnet",
+                            "Ipv6CidrBlocks"
+                        ]
+                    }
+                ]
+            }
+        },
+        "NetworkAclAssociationId": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "NetworkAclAssociationId"
+                ]
+            }
+        },
+        "NetworkType": {
+            "Value": "private"
+        },
+        "RouteTableId": {
+            "Value": {
+                "Ref": "RouteTable"
+            }
+        },
+        "SubnetId": {
+            "Value": {
+                "Ref": "Subnet"
+            }
+        },
+        "SubnetRouteTableAssociationId": {
+            "Value": {
+                "Ref": "SubnetRouteTableAssociation"
+            }
+        },
+        "VpcId": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "VpcId"
+                ]
+            }
+        }
+    },
+    "Resources": {
+        "DefaultRoute": {
+            "Properties": {
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "GatewayId": {
+                    "Ref": "AWS::NoValue"
+                },
+                "NatGatewayId": "nat-abc1234z",
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                }
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "RouteTable": {
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "NetworkType",
+                        "Value": "private"
+                    }
+                ],
+                "VpcId": "vpcabc1234"
+            },
+            "Type": "AWS::EC2::RouteTable"
+        },
+        "Subnet": {
+            "Properties": {
+                "AvailabilityZone": "us-east-1a",
+                "CidrBlock": "10.0.0.0/24",
+                "Tags": [
+                    {
+                        "Key": "NetworkType",
+                        "Value": "private"
+                    }
+                ],
+                "VpcId": "vpcabc1234"
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "SubnetRouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "Subnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        }
+    }
+}

--- a/tests/fixtures/blueprints/network_public_with_multiple_routes.json
+++ b/tests/fixtures/blueprints/network_public_with_multiple_routes.json
@@ -1,0 +1,149 @@
+{
+    "Outputs": {
+        "AvailabilityZone": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "AvailabilityZone"
+                ]
+            }
+        },
+        "CidrBlock": {
+            "Value": "10.0.0.0/24"
+        },
+        "DefaultRouteId": {
+            "Value": {
+                "Ref": "DefaultRoute"
+            }
+        },
+        "Ipv6CidrBlocks": {
+            "Value": {
+                "Fn::Join": [
+                    ",",
+                    {
+                        "Fn::GetAtt": [
+                            "Subnet",
+                            "Ipv6CidrBlocks"
+                        ]
+                    }
+                ]
+            }
+        },
+        "NetworkAclAssociationId": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "NetworkAclAssociationId"
+                ]
+            }
+        },
+        "NetworkType": {
+            "Value": "public"
+        },
+        "Route1": {
+            "Value": {
+                "Ref": "Route1"
+            }
+        },
+        "Route2": {
+            "Value": {
+                "Ref": "Route2"
+            }
+        },
+        "RouteTableId": {
+            "Value": {
+                "Ref": "RouteTable"
+            }
+        },
+        "SubnetId": {
+            "Value": {
+                "Ref": "Subnet"
+            }
+        },
+        "SubnetRouteTableAssociationId": {
+            "Value": {
+                "Ref": "SubnetRouteTableAssociation"
+            }
+        },
+        "VpcId": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "VpcId"
+                ]
+            }
+        }
+    },
+    "Resources": {
+        "DefaultRoute": {
+            "Properties": {
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "GatewayId": "gw-abc1234z",
+                "NatGatewayId": {
+                    "Ref": "AWS::NoValue"
+                },
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                }
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "Route1": {
+            "Properties": {
+                "DestinationCidrBlock": "127.127.127.127/32",
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                },
+                "VpcPeeringConnectionId": "pcx-abcde123456789000"
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "Route2": {
+            "Properties": {
+                "DestinationCidrBlock": "127.127.127.128/32",
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                },
+                "VpcPeeringConnectionId": "pcx-abcde123456789001"
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "RouteTable": {
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "NetworkType",
+                        "Value": "public"
+                    }
+                ],
+                "VpcId": "vpcabc1234"
+            },
+            "Type": "AWS::EC2::RouteTable"
+        },
+        "Subnet": {
+            "Properties": {
+                "AvailabilityZone": "us-east-1a",
+                "CidrBlock": "10.0.0.0/24",
+                "Tags": [
+                    {
+                        "Key": "NetworkType",
+                        "Value": "public"
+                    }
+                ],
+                "VpcId": "vpcabc1234"
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "SubnetRouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "Subnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        }
+    }
+}

--- a/tests/fixtures/blueprints/network_public_with_single_route.json
+++ b/tests/fixtures/blueprints/network_public_with_single_route.json
@@ -1,0 +1,134 @@
+{
+    "Outputs": {
+        "AvailabilityZone": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "AvailabilityZone"
+                ]
+            }
+        },
+        "CidrBlock": {
+            "Value": "10.0.0.0/24"
+        },
+        "DefaultRouteId": {
+            "Value": {
+                "Ref": "DefaultRoute"
+            }
+        },
+        "Ipv6CidrBlocks": {
+            "Value": {
+                "Fn::Join": [
+                    ",",
+                    {
+                        "Fn::GetAtt": [
+                            "Subnet",
+                            "Ipv6CidrBlocks"
+                        ]
+                    }
+                ]
+            }
+        },
+        "NetworkAclAssociationId": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "NetworkAclAssociationId"
+                ]
+            }
+        },
+        "NetworkType": {
+            "Value": "public"
+        },
+        "Route1": {
+            "Value": {
+                "Ref": "Route1"
+            }
+        },
+        "RouteTableId": {
+            "Value": {
+                "Ref": "RouteTable"
+            }
+        },
+        "SubnetId": {
+            "Value": {
+                "Ref": "Subnet"
+            }
+        },
+        "SubnetRouteTableAssociationId": {
+            "Value": {
+                "Ref": "SubnetRouteTableAssociation"
+            }
+        },
+        "VpcId": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "VpcId"
+                ]
+            }
+        }
+    },
+    "Resources": {
+        "DefaultRoute": {
+            "Properties": {
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "GatewayId": "gw-abc1234z",
+                "NatGatewayId": {
+                    "Ref": "AWS::NoValue"
+                },
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                }
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "Route1": {
+            "Properties": {
+                "DestinationCidrBlock": "127.127.127.127/32",
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                },
+                "VpcPeeringConnectionId": "pcx-abcde123456789000"
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "RouteTable": {
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "NetworkType",
+                        "Value": "public"
+                    }
+                ],
+                "VpcId": "vpcabc1234"
+            },
+            "Type": "AWS::EC2::RouteTable"
+        },
+        "Subnet": {
+            "Properties": {
+                "AvailabilityZone": "us-east-1a",
+                "CidrBlock": "10.0.0.0/24",
+                "Tags": [
+                    {
+                        "Key": "NetworkType",
+                        "Value": "public"
+                    }
+                ],
+                "VpcId": "vpcabc1234"
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "SubnetRouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "Subnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        }
+    }
+}

--- a/tests/fixtures/blueprints/network_public_without_extra_routes.json
+++ b/tests/fixtures/blueprints/network_public_without_extra_routes.json
@@ -1,0 +1,119 @@
+{
+    "Outputs": {
+        "AvailabilityZone": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "AvailabilityZone"
+                ]
+            }
+        },
+        "CidrBlock": {
+            "Value": "10.0.0.0/24"
+        },
+        "DefaultRouteId": {
+            "Value": {
+                "Ref": "DefaultRoute"
+            }
+        },
+        "Ipv6CidrBlocks": {
+            "Value": {
+                "Fn::Join": [
+                    ",",
+                    {
+                        "Fn::GetAtt": [
+                            "Subnet",
+                            "Ipv6CidrBlocks"
+                        ]
+                    }
+                ]
+            }
+        },
+        "NetworkAclAssociationId": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "NetworkAclAssociationId"
+                ]
+            }
+        },
+        "NetworkType": {
+            "Value": "public"
+        },
+        "RouteTableId": {
+            "Value": {
+                "Ref": "RouteTable"
+            }
+        },
+        "SubnetId": {
+            "Value": {
+                "Ref": "Subnet"
+            }
+        },
+        "SubnetRouteTableAssociationId": {
+            "Value": {
+                "Ref": "SubnetRouteTableAssociation"
+            }
+        },
+        "VpcId": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "Subnet",
+                    "VpcId"
+                ]
+            }
+        }
+    },
+    "Resources": {
+        "DefaultRoute": {
+            "Properties": {
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "GatewayId": "gw-abc1234z",
+                "NatGatewayId": {
+                    "Ref": "AWS::NoValue"
+                },
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                }
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "RouteTable": {
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "NetworkType",
+                        "Value": "public"
+                    }
+                ],
+                "VpcId": "vpcabc1234"
+            },
+            "Type": "AWS::EC2::RouteTable"
+        },
+        "Subnet": {
+            "Properties": {
+                "AvailabilityZone": "us-east-1a",
+                "CidrBlock": "10.0.0.0/24",
+                "Tags": [
+                    {
+                        "Key": "NetworkType",
+                        "Value": "public"
+                    }
+                ],
+                "VpcId": "vpcabc1234"
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "SubnetRouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "RouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "Subnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        }
+    }
+}

--- a/tests/test_efs.py
+++ b/tests/test_efs.py
@@ -10,7 +10,11 @@ from stacker_blueprints.efs import ElasticFileSystem
 
 EFS_VARIABLES = {
     'VpcId': 'vpc-11111111',
-    'PerformanceMode': 'generalPurpose',
+    'FileSystem': {
+      'EfsFileSystem': {
+        'PerformanceMode': 'generalPurpose'
+      }
+    },
     'Tags': {
         'Hello': 'World'
     },

--- a/tests/test_efs.py
+++ b/tests/test_efs.py
@@ -47,24 +47,6 @@ class TestElasticFileSystem(BlueprintTestCase):
     def setUp(self):
         self.ctx = Context({'namespace': 'test'})
 
-    def test_create_template_with_subnets(self):
-        blueprint = ElasticFileSystem('test_efs_ElasticFileSystem', self.ctx)
-        variables = EFS_VARIABLES.copy()
-        variables.update(SUBNETS)
-        blueprint.resolve_variables(
-            [Variable(k, v) for k, v in variables.items()])
-        blueprint.create_template()
-        self.assertRenderedBlueprint(blueprint)
-
-    def test_create_template_with_subnet_str(self):
-        blueprint = ElasticFileSystem('test_efs_ElasticFileSystem', self.ctx)
-        variables = EFS_VARIABLES.copy()
-        variables.update(SUBNETS_STR)
-        blueprint.resolve_variables(
-            [Variable(k, v) for k, v in variables.items()])
-        blueprint.create_template()
-        self.assertRenderedBlueprint(blueprint)
-
     def test_validate_security_group_count_empty(self):
         blueprint = ElasticFileSystem('test_efs_ElasticFileSystem', self.ctx)
         variables = EFS_VARIABLES.copy()

--- a/tests/test_efs.yaml
+++ b/tests/test_efs.yaml
@@ -2,7 +2,9 @@
 
 efs_variables: &efs_variables
   VpcId: 'vpc-11111111'
-  PerformanceMode: 'generalPurpose'
+  FileSystem:
+    EfsFileSystem:
+      PerformanceMode: 'generalPurpose'
   Tags:
     Hello: 'World'
   Subnets:

--- a/tests/test_efs.yaml
+++ b/tests/test_efs.yaml
@@ -64,7 +64,7 @@ stacks:
         <<: *security_group_1
         <<: *security_group_2
 
-  - name: access_points
+  - name: efs_access_points
     class_path: stacker_blueprints.efs.AccessPoints
     variables:
       AccessPoints:

--- a/tests/test_efs.yaml
+++ b/tests/test_efs.yaml
@@ -14,6 +14,8 @@ efs_variables: &efs_variables
     - 'sg-22222222'
     - 'sg-33333333'
 
+  efs_id: &efs_id fs-11111111
+
 
 Subnets: &subnets
   - 'subnet-11111111'
@@ -61,3 +63,22 @@ stacks:
       SecurityGroups:
         <<: *security_group_1
         <<: *security_group_2
+
+  - name: access_points
+    class_path: stacker_blueprints.efs.AccessPoints
+    variables:
+      AccessPoints:
+        FirstAccessPoint:
+          AccessPointTags:
+            - Key: 'Tag1'
+              Value: 'Value1'
+          FileSystemId: *efs_id
+          PosixUser:
+            Uid: '1000'
+            Gid: '1000'
+          RootDirectory:
+            Path: '/data'
+            CreationInfo:
+              OwnerGid: '1000'
+              OwnerUid: '1000'
+              Permissions: '755'

--- a/tests/test_efs.yaml
+++ b/tests/test_efs.yaml
@@ -7,15 +7,19 @@ efs_variables: &efs_variables
       PerformanceMode: 'generalPurpose'
   Tags:
     Hello: 'World'
-  Subnets:
-    - 'subnet-11111111'
-    - 'subnet-22222222'
   IpAddresses:
     - '172.16.1.10'
     - '172.16.2.10'
   ExtraSecurityGroups:
     - 'sg-22222222'
     - 'sg-33333333'
+
+
+Subnets: &subnets
+  - 'subnet-11111111'
+  - 'subnet-22222222'
+
+SubnetsStr: &subnets_str 'subnet-33333333,subnet-44444444'
 
 security_group_1: &security_group_1
   EfsSg1:
@@ -41,10 +45,19 @@ security_group_2: &security_group_2
 
 namespace: test
 stacks:
-  - name: efs
+  - name: efs_with_subnets
     class_path: stacker_blueprints.efs.ElasticFileSystem
     variables:
       << : *efs_variables
+      Subnets: *subnets
+      SecurityGroups:
+        <<: *security_group_1
+        <<: *security_group_2
+  - name: efs_with_subnets_str
+    class_path: stacker_blueprints.efs.ElasticFileSystem
+    variables:
+      << : *efs_variables
+      SubnetsStr: *subnets_str
       SecurityGroups:
         <<: *security_group_1
         <<: *security_group_2

--- a/tests/test_efs.yaml
+++ b/tests/test_efs.yaml
@@ -1,0 +1,48 @@
+---
+
+efs_variables: &efs_variables
+  VpcId: 'vpc-11111111'
+  PerformanceMode: 'generalPurpose'
+  Tags:
+    Hello: 'World'
+  Subnets:
+    - 'subnet-11111111'
+    - 'subnet-22222222'
+  IpAddresses:
+    - '172.16.1.10'
+    - '172.16.2.10'
+  ExtraSecurityGroups:
+    - 'sg-22222222'
+    - 'sg-33333333'
+
+security_group_1: &security_group_1
+  EfsSg1:
+    GroupDescription: 'EFS SG 1'
+    SecurityGroupIngress:
+      - IpProtocol: 'tcp'
+        FromPort: 2049
+        ToPort: 2049
+        CidrIp: '172.16.0.0/12'
+    Tags:
+      - Key: 'Foo'
+        Value: 'Bar'
+
+security_group_2: &security_group_2
+  EfsSg2:
+    GroupDescription: 'EFS SG 2'
+    SecurityGroupIngress:
+      - IpProtocol: 'tcp'
+        FromPort: 2049
+        ToPort: 2049
+        SourceSecurityGroupId: 'sg-11111111'
+
+
+namespace: test
+stacks:
+  - name: efs
+    class_path: stacker_blueprints.efs.ElasticFileSystem
+    variables:
+      << : *efs_variables
+      SecurityGroups:
+        <<: *security_group_1
+        <<: *security_group_2

--- a/tests/test_msk.yaml
+++ b/tests/test_msk.yaml
@@ -1,0 +1,97 @@
+namespace: test
+
+definitions:
+  class_path: &class_path stacker_blueprints.msk.Cluster
+  client_subnets: &client_subnets
+    ClientSubnets:
+      - subnet-abc09876
+      - subnet-def54321
+      - subnet-cdb5678
+  cluster_tags: &cluster_tags
+    Tags:
+      - Key: MyKey1
+        Value: myValue1
+      - Key: MyKey2
+        Value: myValue2
+      - Key: MyKey3
+        Value: myValue3
+  configuration_info: &configuration_info
+    ConfigurationInfo:
+      Arn: arn:aws:kafka:us-east-1:000000000011:configuration/ConfigName/abcdef0-1234-5678-9abc-0123456789ab-2
+      Revision: 1
+  security_groups: &security_groups
+    SecurityGroups:
+      - sg-abcdef0123456789a
+
+stacks:
+  - name: msk_cluster_base
+    class_path: *class_path
+    variables:
+      Clusters:
+        testCluster:
+          BrokerNodeGroupInfo:
+            BrokerAZDistribution: DEFAULT
+            <<: *client_subnets
+            InstanceType: kafka.m5.xlarge
+            <<: *security_groups
+            StorageInfo:
+              EBSStorageInfo:
+                VolumeSize: 800
+          ClusterName: test-kafka
+          <<: *configuration_info
+          EncryptionInfo:
+            EncryptionInTransit:
+              ClientBroker: TLS_PLAINTEXT
+              InCluster: false
+          EnhancedMonitoring: PER_TOPIC_PER_BROKER
+          KafkaVersion: 1.1.1
+          NumberOfBrokerNodes: 3
+          <<: *cluster_tags
+
+  - name: msk_cluster_with_required_opts
+    class_path: *class_path
+    variables:
+      Clusters:
+        ClusterWithRequiredProperties:
+          ClusterName: ClusterWithRequiredProperties
+          KafkaVersion: 2.2.1
+          NumberOfBrokerNodes: 3
+          BrokerNodeGroupInfo:
+            InstanceType: kafka.m5.large
+            <<: *client_subnets
+
+  - name: msk_cluster_all_required_opts
+    class_path: *class_path
+    variables:
+      Clusters:
+        ClusterWithAllProperties:
+          ClusterName: ClusterWithAllProperties
+          KafkaVersion: 2.2.1
+          NumberOfBrokerNodes: 3
+          EnhancedMonitoring: PER_BROKER
+          EncryptionInfo:
+            EncryptionAtRest:
+              DataVolumeKMSKeyId: ReplaceWithKmsKeyArn
+            EncryptionInTransit:
+              ClientBroker: TLS
+              InCluster: true
+          OpenMonitoring:
+            Prometheus:
+              JmxExporter:
+                EnabledInBroker: "true"
+              NodeExporter:
+                EnabledInBroker: "true"
+          <<: *configuration_info
+          ClientAuthentication:
+            Tls:
+              CertificateAuthorityArnList:
+                - ReplaceWithCAArn
+          <<: *cluster_tags
+          BrokerNodeGroupInfo:
+            BrokerAZDistribution: DEFAULT
+            InstanceType: kafka.m5.large
+            <<: *security_groups
+            StorageInfo:
+              EBSStorageInfo:
+                VolumeSize: 100
+            <<: *client_subnets

--- a/tests/test_msk.yaml
+++ b/tests/test_msk.yaml
@@ -9,12 +9,9 @@ definitions:
       - subnet-cdb5678
   cluster_tags: &cluster_tags
     Tags:
-      - Key: MyKey1
-        Value: myValue1
-      - Key: MyKey2
-        Value: myValue2
-      - Key: MyKey3
-        Value: myValue3
+      MyKey1: myValue1
+      MyKey2: myValue2
+      MyKey3: myValue3
   configuration_info: &configuration_info
     ConfigurationInfo:
       Arn: arn:aws:kafka:us-east-1:000000000011:configuration/ConfigName/abcdef0-1234-5678-9abc-0123456789ab-2

--- a/tests/test_network.yaml
+++ b/tests/test_network.yaml
@@ -1,0 +1,68 @@
+---
+
+
+class_path: &class_path stacker_blueprints.network.Network
+common_variables: &common_variables
+  VpcId: 'vpcabc1234'
+  VpcDefaultSecurityGroup: 'sg-01234abc'
+  AvailabilityZone: 'us-east-1a'
+  CidrBlock: '10.0.0.0/24'
+
+
+route_1: &route_1
+  DestinationCidrBlock: "127.127.127.127/32"
+  VpcPeeringConnectionId: "pcx-abcde123456789000"
+
+route_2: &route_2
+  DestinationCidrBlock: "127.127.127.128/32"
+  VpcPeeringConnectionId: "pcx-abcde123456789001"
+
+namespace: test
+stacks:
+  - name: network_public_without_extra_routes
+    class_path: *class_path
+    variables:
+      << : *common_variables
+      InternetGatewayId: 'gw-abc1234z'
+  - name: network_public_with_single_route
+    class_path: *class_path
+    variables:
+      << : *common_variables
+      InternetGatewayId: 'gw-abc1234z'
+      Routes:
+        Route1:
+          <<: *route_1
+  - name: network_public_with_multiple_routes
+    class_path: *class_path
+    variables:
+      << : *common_variables
+      InternetGatewayId: 'gw-abc1234z'
+      Routes:
+        Route1:
+          <<: *route_1
+        Route2:
+          <<: *route_2
+
+  - name: network_private_without_extra_routes
+    class_path: *class_path
+    variables:
+      << : *common_variables
+      NatGatewayId: 'nat-abc1234z'
+  - name: network_private_with_single_route
+    class_path: *class_path
+    variables:
+      << : *common_variables
+      NatGatewayId: 'nat-abc1234z'
+      Routes:
+        Route1:
+          <<: *route_1
+  - name: network_private_with_multiple_routes
+    class_path: *class_path
+    variables:
+      << : *common_variables
+      NatGatewayId: 'nat-abc1234z'
+      Routes:
+        Route1:
+          <<: *route_1
+        Route2:
+          <<: *route_2


### PR DESCRIPTION
In order not to lose track of EFS :: FileSystem updates, we are moving from the raw dictionary to a TroposphereType (troposphere.efs.FileSystem).
We also adopt yaml tests for success tests and keep the file test_efs.py for failure tests only.