### PR TITLE
Enable docker builds on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,9 @@
-version: 2
+---
+version: 2.1
 
 defaults: &defaults
   docker:
-    - image: circleci/python:2.7
+    - image: library/docker:latest
 
 workflows:
   version: 2
@@ -16,13 +17,34 @@ jobs:
     << : *defaults
 
     steps:
+      - run: apk --update add git
       - checkout
-      - run: sudo pip install flake8 codecov pep8-naming
-      - run: sudo make lint
+      - setup_remote_docker
+      - build
+      - docker_run:
+          cmd: flake8 stacker_blueprints
 
   test-unit:
     << : *defaults
 
     steps:
+      - run: apk --update add git
       - checkout
-      - run: sudo make test
+      - setup_remote_docker
+      - build
+      - docker_run:
+          cmd: python setup.py test
+
+commands:
+  build:
+    description: Build the docker image to use in later steps.
+    steps:
+      - run: docker build --tag localhost/stacker_blueprints:latest .
+  docker_run:
+    description: Run a command using the image from the build command.
+    parameters:
+      cmd:
+        description: The command you'd like to run.
+        type: string
+    steps:
+      - run: docker run -it localhost/stacker_blueprints:latest <<parameters.cmd>>

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ dev.env
 
 # Ignore semaphore files for make targets
 .build
+.circleci/circleci
+.circleci/process.yml
+.circleci/.validated

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .DEFAULT_GOAL := all
 tag ?= localhost/stacker_blueprints:latest
 
-docker_run := docker run -it --rm -v $(pwd):/usr/local/src/stacker_blueprints $(tag)
+docker_run := docker run -it --rm -v $(shell pwd):/usr/local/src/stacker_blueprints $(tag)
 
 .PHONY: all
-all: lint test
+all: lint test circle
 
 lint: .build stacker_blueprints
 	@$(docker_run) flake8 stacker_blueprints
@@ -21,4 +21,31 @@ test: .build stacker_blueprints tests
 
 .PHONY: shell
 shell: .build
-	@$(docker_run) bash
+	$(docker_run) bash
+
+# Run the circle jobs locally.
+# https://circleci.com/docs/2.0/local-cli/#running-a-job
+.PHONY: circle
+circle: .circleci/process.yml
+	.circleci/circleci local execute -c .circleci/process.yml --job lint
+	.circleci/circleci local execute -c .circleci/process.yml --job test-unit
+
+# Run the circleci CLI validator on the config file.
+.circleci/.validated: .circleci/config.yml
+	@docker run -it --rm \
+		-v $(shell pwd):/data \
+		circleci/circleci-cli:alpine \
+			config validate /data/.circleci/config.yml
+	@touch .circleci/.validated
+
+# Convert the friendly config.yml to a ready-to-process process.yml.
+# https://circleci.com/docs/2.0/local-cli/#running-a-job
+.circleci/process.yml: .circleci/.validated
+	@$(eval cid := $(shell docker create \
+		-v $(shell pwd):/data \
+		--entrypoint /bin/sh \
+		circleci/circleci-cli:alpine \
+			-c 'circleci config process /data/.circleci/config.yml > /data/.circleci/process.yml'))
+	@docker start -ai $(cid)
+	@docker cp $(cid):/usr/local/bin/circleci .circleci/circleci
+	@docker rm $(cid)

--- a/README.rst
+++ b/README.rst
@@ -14,3 +14,26 @@ stacker_blueprints
 An attempt at a common Blueprint library for use with `stacker <https://github.com/cloudtools/stacker>`_.
 
 If you're new to stacker you may use `stacker_cookiecutter <https://github.com/cloudtools/stacker_cookiecutter>`_ to setup your project.
+
+Running Tests
+=============
+
+To run tests locally, you need to be on an amd64 machine, and have the following
+dependencies:
+
+* Make (tested against GNU Make)
+* Docker (tested against version ``19.03.12-ce``)
+
+Then, you can run the whole test suite by invoking ``make``. You may find the
+following recipes useful while developing:
+
+* ``make lint``
+* ``make test``
+* ``make shell``
+
+  This will provide you a shell inside the container used to run
+  tests/linting/etc.
+* ``make circle``
+
+  This will run the CircleCI test suite locally. It's not a perfect emulation of
+  CircleCI, but will help catch errors in your configuration.


### PR DESCRIPTION
This changes the test runs on CircleCI to run in Docker, and allows
running the CircleCI tests locally via the circleci CLI.