### PR TITLE
rds: Enable support for Cloudwatch logs exports

### DIFF
--- a/stacker_blueprints/rds/aurora/base.py
+++ b/stacker_blueprints/rds/aurora/base.py
@@ -54,6 +54,11 @@ class Cluster(Blueprint):
             "type": str,
             "description": "A comma separated list of subnet ids."
         },
+        "EnableCloudwatchLogsExports": {
+            "type": list,
+            "description": "List of log types to export to CloudWatch logs.",
+            "default": []
+        },
         "EnableIAMDatabaseAuthentication": {
             "type": bool,
             "description": "Whether or not to permit IAM db access.",
@@ -274,6 +279,9 @@ class Cluster(Blueprint):
             BackupRetentionPeriod=variables["BackupRetentionPeriod"],
             DBClusterParameterGroupName=parameter_group,
             DBSubnetGroupName=Ref(SUBNET_GROUP),
+            EnableCloudwatchLogsExports=variables[
+                "EnableCloudwatchLogsExports"
+            ],
             EnableIAMDatabaseAuthentication=variables[
                 "EnableIAMDatabaseAuthentication"
             ],

--- a/tests/fixtures/blueprints/rds_aurora_base_cluster.json
+++ b/tests/fixtures/blueprints/rds_aurora_base_cluster.json
@@ -4,106 +4,107 @@
             "Value": {
                 "Ref": "DBCluster"
             }
-        },
+        }, 
         "MasterEndpoint": {
             "Value": {
                 "Fn::GetAtt": [
-                    "DBCluster",
+                    "DBCluster", 
                     "Endpoint.Address"
                 ]
             }
-        },
+        }, 
         "Port": {
             "Value": {
                 "Fn::GetAtt": [
-                    "DBCluster",
+                    "DBCluster", 
                     "Endpoint.Port"
                 ]
             }
-        },
+        }, 
         "ReadEndpoint": {
             "Value": {
                 "Fn::GetAtt": [
-                    "DBCluster",
+                    "DBCluster", 
                     "ReadEndpoint.Address"
                 ]
             }
-        },
+        }, 
         "SecurityGroup": {
             "Value": {
                 "Ref": "SecurityGroup"
             }
-        },
+        }, 
         "SubnetGroup": {
             "Value": {
                 "Ref": "SubnetGroup"
             }
         }
-    },
+    }, 
     "Parameters": {
         "MasterUserPassword": {
-            "Default": "",
-            "Description": "Master user password.",
-            "NoEcho": true,
+            "Default": "", 
+            "Description": "Master user password.", 
+            "NoEcho": true, 
             "Type": "String"
         }
-    },
+    }, 
     "Resources": {
         "DBCluster": {
-            "DeletionPolicy": "Snapshot",
+            "DeletionPolicy": "Snapshot", 
             "Properties": {
-                "BackupRetentionPeriod": 7,
-                "DBClusterParameterGroupName": "default.postgres9.3",
+                "BackupRetentionPeriod": 7, 
+                "DBClusterParameterGroupName": "default.postgres9.3", 
                 "DBSubnetGroupName": {
                     "Ref": "SubnetGroup"
-                },
-                "DatabaseName": "db",
-                "EnableIAMDatabaseAuthentication": "false",
-                "Engine": "aurora",
-                "EngineVersion": "9.3.10",
+                }, 
+                "DatabaseName": "db", 
+                "EnableCloudwatchLogsExports": [], 
+                "EnableIAMDatabaseAuthentication": "false", 
+                "Engine": "aurora", 
+                "EngineVersion": "9.3.10", 
                 "MasterUserPassword": {
                     "Ref": "MasterUserPassword"
-                },
-                "MasterUsername": "root",
-                "Port": 3306,
-                "PreferredBackupWindow": "12:00-13:00",
-                "PreferredMaintenanceWindow": "Sun:11:00-Sun:12:00",
+                }, 
+                "MasterUsername": "root", 
+                "Port": 3306, 
+                "PreferredBackupWindow": "12:00-13:00", 
+                "PreferredMaintenanceWindow": "Sun:11:00-Sun:12:00", 
                 "ReplicationSourceIdentifier": {
                     "Ref": "AWS::NoValue"
-                },
+                }, 
                 "SnapshotIdentifier": {
                     "Ref": "AWS::NoValue"
-                },
-                "StorageEncrypted": "true",
+                }, 
+                "StorageEncrypted": "true", 
                 "Tags": [
                     {
-                        "Key": "Name",
+                        "Key": "Name", 
                         "Value": "rds_aurora_base_cluster"
                     }
-                ],
+                ], 
                 "VpcSecurityGroupIds": [
                     {
                         "Ref": "SecurityGroup"
                     }
                 ]
-            },
+            }, 
             "Type": "AWS::RDS::DBCluster"
-        },
+        }, 
         "SecurityGroup": {
             "Properties": {
-                "GroupDescription": "rds_aurora_base_cluster RDS security group",
+                "GroupDescription": "rds_aurora_base_cluster RDS security group", 
                 "VpcId": "vpc-1234"
-            },
+            }, 
             "Type": "AWS::EC2::SecurityGroup"
-        },
+        }, 
         "SubnetGroup": {
             "Properties": {
-                "DBSubnetGroupDescription": "rds_aurora_base_cluster VPC subnet group.",
+                "DBSubnetGroupDescription": "rds_aurora_base_cluster VPC subnet group.", 
                 "SubnetIds": [
-                    "subnet-1234",
+                    "subnet-1234", 
                     "subnet-4321"
                 ]
-            },
+            }, 
             "Type": "AWS::RDS::DBSubnetGroup"
         }
     }

--- a/tests/fixtures/blueprints/rds_aurora_base_cluster_cloudwatch_logs_export.json
+++ b/tests/fixtures/blueprints/rds_aurora_base_cluster_cloudwatch_logs_export.json
@@ -53,15 +53,17 @@
             "DeletionPolicy": "Snapshot", 
             "Properties": {
                 "BackupRetentionPeriod": 7, 
-                "DBClusterParameterGroupName": "default.aurora-mysql5.7", 
+                "DBClusterParameterGroupName": "default.postgres9.3", 
                 "DBSubnetGroupName": {
                     "Ref": "SubnetGroup"
                 }, 
                 "DatabaseName": "db", 
-                "EnableCloudwatchLogsExports": [], 
+                "EnableCloudwatchLogsExports": [
+                    "postgres"
+                ], 
                 "EnableIAMDatabaseAuthentication": "false", 
-                "Engine": "aurora-mysql", 
-                "EngineVersion": "5.7.12", 
+                "Engine": "aurora", 
+                "EngineVersion": "9.3.10", 
                 "MasterUserPassword": {
                     "Ref": "MasterUserPassword"
                 }, 
@@ -79,7 +81,7 @@
                 "Tags": [
                     {
                         "Key": "Name", 
-                        "Value": "rds_aurora_mysql_cluster"
+                        "Value": "rds_aurora_base_cluster_cloudwatch_logs_export"
                     }
                 ], 
                 "VpcSecurityGroupIds": [
@@ -92,14 +94,14 @@
         }, 
         "SecurityGroup": {
             "Properties": {
-                "GroupDescription": "rds_aurora_mysql_cluster RDS security group", 
+                "GroupDescription": "rds_aurora_base_cluster_cloudwatch_logs_export RDS security group", 
                 "VpcId": "vpc-1234"
             }, 
             "Type": "AWS::EC2::SecurityGroup"
         }, 
         "SubnetGroup": {
             "Properties": {
-                "DBSubnetGroupDescription": "rds_aurora_mysql_cluster VPC subnet group.", 
+                "DBSubnetGroupDescription": "rds_aurora_base_cluster_cloudwatch_logs_export VPC subnet group.", 
                 "SubnetIds": [
                     "subnet-1234", 
                     "subnet-4321"

--- a/tests/fixtures/blueprints/rds_aurora_base_cluster_iam_access.json
+++ b/tests/fixtures/blueprints/rds_aurora_base_cluster_iam_access.json
@@ -4,106 +4,107 @@
             "Value": {
                 "Ref": "DBCluster"
             }
-        },
+        }, 
         "MasterEndpoint": {
             "Value": {
                 "Fn::GetAtt": [
-                    "DBCluster",
+                    "DBCluster", 
                     "Endpoint.Address"
                 ]
             }
-        },
+        }, 
         "Port": {
             "Value": {
                 "Fn::GetAtt": [
-                    "DBCluster",
+                    "DBCluster", 
                     "Endpoint.Port"
                 ]
             }
-        },
+        }, 
         "ReadEndpoint": {
             "Value": {
                 "Fn::GetAtt": [
-                    "DBCluster",
+                    "DBCluster", 
                     "ReadEndpoint.Address"
                 ]
             }
-        },
+        }, 
         "SecurityGroup": {
             "Value": {
                 "Ref": "SecurityGroup"
             }
-        },
+        }, 
         "SubnetGroup": {
             "Value": {
                 "Ref": "SubnetGroup"
             }
         }
-    },
+    }, 
     "Parameters": {
         "MasterUserPassword": {
-            "Default": "",
-            "Description": "Master user password.",
-            "NoEcho": true,
+            "Default": "", 
+            "Description": "Master user password.", 
+            "NoEcho": true, 
             "Type": "String"
         }
-    },
+    }, 
     "Resources": {
         "DBCluster": {
-            "DeletionPolicy": "Snapshot",
+            "DeletionPolicy": "Snapshot", 
             "Properties": {
-                "BackupRetentionPeriod": 7,
-                "DBClusterParameterGroupName": "default.postgres9.3",
+                "BackupRetentionPeriod": 7, 
+                "DBClusterParameterGroupName": "default.postgres9.3", 
                 "DBSubnetGroupName": {
                     "Ref": "SubnetGroup"
-                },
-                "DatabaseName": "db",
-                "EnableIAMDatabaseAuthentication": "true",
-                "Engine": "aurora",
-                "EngineVersion": "9.3.10",
+                }, 
+                "DatabaseName": "db", 
+                "EnableCloudwatchLogsExports": [], 
+                "EnableIAMDatabaseAuthentication": "true", 
+                "Engine": "aurora", 
+                "EngineVersion": "9.3.10", 
                 "MasterUserPassword": {
                     "Ref": "MasterUserPassword"
-                },
-                "MasterUsername": "root",
-                "Port": 3306,
-                "PreferredBackupWindow": "12:00-13:00",
-                "PreferredMaintenanceWindow": "Sun:11:00-Sun:12:00",
+                }, 
+                "MasterUsername": "root", 
+                "Port": 3306, 
+                "PreferredBackupWindow": "12:00-13:00", 
+                "PreferredMaintenanceWindow": "Sun:11:00-Sun:12:00", 
                 "ReplicationSourceIdentifier": {
                     "Ref": "AWS::NoValue"
-                },
+                }, 
                 "SnapshotIdentifier": {
                     "Ref": "AWS::NoValue"
-                },
-                "StorageEncrypted": "true",
+                }, 
+                "StorageEncrypted": "true", 
                 "Tags": [
                     {
-                        "Key": "Name",
+                        "Key": "Name", 
                         "Value": "rds_aurora_base_cluster_iam_access"
                     }
-                ],
+                ], 
                 "VpcSecurityGroupIds": [
                     {
                         "Ref": "SecurityGroup"
                     }
                 ]
-            },
+            }, 
             "Type": "AWS::RDS::DBCluster"
-        },
+        }, 
         "SecurityGroup": {
             "Properties": {
-                "GroupDescription": "rds_aurora_base_cluster_iam_access RDS security group",
+                "GroupDescription": "rds_aurora_base_cluster_iam_access RDS security group", 
                 "VpcId": "vpc-1234"
-            },
+            }, 
             "Type": "AWS::EC2::SecurityGroup"
-        },
+        }, 
         "SubnetGroup": {
             "Properties": {
-                "DBSubnetGroupDescription": "rds_aurora_base_cluster_iam_access VPC subnet group.",
+                "DBSubnetGroupDescription": "rds_aurora_base_cluster_iam_access VPC subnet group.", 
                 "SubnetIds": [
-                    "subnet-1234",
+                    "subnet-1234", 
                     "subnet-4321"
                 ]
-            },
+            }, 
             "Type": "AWS::RDS::DBSubnetGroup"
         }
     }

--- a/tests/fixtures/blueprints/rds_aurora_base_cluster_restore_snapshot.json
+++ b/tests/fixtures/blueprints/rds_aurora_base_cluster_restore_snapshot.json
@@ -4,106 +4,107 @@
             "Value": {
                 "Ref": "DBCluster"
             }
-        },
+        }, 
         "MasterEndpoint": {
             "Value": {
                 "Fn::GetAtt": [
-                    "DBCluster",
+                    "DBCluster", 
                     "Endpoint.Address"
                 ]
             }
-        },
+        }, 
         "Port": {
             "Value": {
                 "Fn::GetAtt": [
-                    "DBCluster",
+                    "DBCluster", 
                     "Endpoint.Port"
                 ]
             }
-        },
+        }, 
         "ReadEndpoint": {
             "Value": {
                 "Fn::GetAtt": [
-                    "DBCluster",
+                    "DBCluster", 
                     "ReadEndpoint.Address"
                 ]
             }
-        },
+        }, 
         "SecurityGroup": {
             "Value": {
                 "Ref": "SecurityGroup"
             }
-        },
+        }, 
         "SubnetGroup": {
             "Value": {
                 "Ref": "SubnetGroup"
             }
         }
-    },
+    }, 
     "Parameters": {
         "MasterUserPassword": {
-            "Default": "",
-            "Description": "Master user password.",
-            "NoEcho": true,
+            "Default": "", 
+            "Description": "Master user password.", 
+            "NoEcho": true, 
             "Type": "String"
         }
-    },
+    }, 
     "Resources": {
         "DBCluster": {
-            "DeletionPolicy": "Snapshot",
+            "DeletionPolicy": "Snapshot", 
             "Properties": {
-                "BackupRetentionPeriod": 7,
-                "DBClusterParameterGroupName": "default.postgres9.3",
+                "BackupRetentionPeriod": 7, 
+                "DBClusterParameterGroupName": "default.postgres9.3", 
                 "DBSubnetGroupName": {
                     "Ref": "SubnetGroup"
-                },
-                "DatabaseName": "db",
-                "EnableIAMDatabaseAuthentication": "false",
-                "Engine": "aurora",
-                "EngineVersion": "9.3.10",
+                }, 
+                "DatabaseName": "db", 
+                "EnableCloudwatchLogsExports": [], 
+                "EnableIAMDatabaseAuthentication": "false", 
+                "Engine": "aurora", 
+                "EngineVersion": "9.3.10", 
                 "MasterUserPassword": {
                     "Ref": "AWS::NoValue"
-                },
+                }, 
                 "MasterUsername": {
                     "Ref": "AWS::NoValue"
-                },
-                "Port": 3306,
-                "PreferredBackupWindow": "12:00-13:00",
-                "PreferredMaintenanceWindow": "Sun:11:00-Sun:12:00",
+                }, 
+                "Port": 3306, 
+                "PreferredBackupWindow": "12:00-13:00", 
+                "PreferredMaintenanceWindow": "Sun:11:00-Sun:12:00", 
                 "ReplicationSourceIdentifier": {
                     "Ref": "AWS::NoValue"
-                },
-                "SnapshotIdentifier": "arn:aws:rds:us-east-1:0123456788901:cluster-snapshot:rds:my-snapshot",
-                "StorageEncrypted": "true",
+                }, 
+                "SnapshotIdentifier": "arn:aws:rds:us-east-1:0123456788901:cluster-snapshot:rds:my-snapshot", 
+                "StorageEncrypted": "true", 
                 "Tags": [
                     {
-                        "Key": "Name",
+                        "Key": "Name", 
                         "Value": "rds_aurora_base_cluster_restore_snapshot"
                     }
-                ],
+                ], 
                 "VpcSecurityGroupIds": [
                     {
                         "Ref": "SecurityGroup"
                     }
                 ]
-            },
+            }, 
             "Type": "AWS::RDS::DBCluster"
-        },
+        }, 
         "SecurityGroup": {
             "Properties": {
-                "GroupDescription": "rds_aurora_base_cluster_restore_snapshot RDS security group",
+                "GroupDescription": "rds_aurora_base_cluster_restore_snapshot RDS security group", 
                 "VpcId": "vpc-1234"
-            },
+            }, 
             "Type": "AWS::EC2::SecurityGroup"
-        },
+        }, 
         "SubnetGroup": {
             "Properties": {
-                "DBSubnetGroupDescription": "rds_aurora_base_cluster_restore_snapshot VPC subnet group.",
+                "DBSubnetGroupDescription": "rds_aurora_base_cluster_restore_snapshot VPC subnet group.", 
                 "SubnetIds": [
-                    "subnet-1234",
+                    "subnet-1234", 
                     "subnet-4321"
                 ]
-            },
+            }, 
             "Type": "AWS::RDS::DBSubnetGroup"
         }
     }

--- a/tests/test_rds_aurora.yaml
+++ b/tests/test_rds_aurora.yaml
@@ -24,6 +24,19 @@ stacks:
       MasterUserPassword: unused-password
       DatabaseName: db
       SnapshotIdentifier: arn:aws:rds:us-east-1:0123456788901:cluster-snapshot:rds:my-snapshot
+  - name: rds_aurora_base_cluster_cloudwatch_logs_export
+    class_path: stacker_blueprints.rds.aurora.AuroraCluster
+    variables:
+      EnableCloudwatchLogsExports:
+        - "postgres"
+      Engine: aurora
+      DBFamily: postgres9.3
+      EngineVersion: 9.3.10
+      Subnets: subnet-1234,subnet-4321
+      VpcId: vpc-1234
+      MasterUser: root
+      MasterUserPassword: password
+      DatabaseName: db
   - name: rds_aurora_base_cluster_iam_access
     class_path: stacker_blueprints.rds.aurora.AuroraCluster
     variables:


### PR DESCRIPTION
AWS has released support for exporting logs to Cloudwatch. In order to
use this feature, it must be enabled on the database instance/cluster.
This change adds support for the feature to RDS Aurora clusters.