### PR TITLE
Update elasticache redis engine versions and parameter group families

### DIFF
--- a/stacker_blueprints/elasticache/redis.py
+++ b/stacker_blueprints/elasticache/redis.py
@@ -8,7 +8,8 @@ class RedisReplicationGroup(base.BaseReplicationGroup):
     def get_engine_versions(self):
         return ["2.6.13", "2.8.19", "2.8.21", "2.8.22", "2.8.23", "2.8.24",
                 "2.8.6", "3.2.4", "3.2.6", "4.0.10", "5.0.0", "5.0.3", "5.0.4",
-                "5.0.5"]
+                "5.0.5", "5.0.6", "6.x"]
 
     def get_parameter_group_family(self):
-        return ["redis2.6", "redis2.8", "redis3.2", "redis4.0", "redis5.0"]
+        return ["redis2.6", "redis2.8", "redis3.2", "redis4.0", "redis5.0",
+                "redis6.x"]


### PR DESCRIPTION
Added engine versions 5.0.6 and 6.x.